### PR TITLE
feat: update pip conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,26 @@ with:
 
 ## Inputs
 
-| Input              | Description                                                                      | Default  |
-| ------------------ | -------------------------------------------------------------------------------- | -------- |
-| `auto-load-pod`    | Which pod to load on startup of LocalStack  (application preview)                | `None`   |
-| `ci-project`          | Name of the CI project to track in LocalStack Cloud |  |
-| `configuration`    | Configuration variables to use while starting LocalStack container               | `None`   |
-| `extension-auto-install` | Which extensions to install on startup of LocalStack (application preview) | `None`   | 
-| `github-token`          | Github token used to create PR comments |  |
-| `image-tag`        | Tag of the LocalStack Docker image to use                                        | `latest` |
-| `include-preview`          | Whether to include the created Ephemeral Instance URL in the PR comment | `false` |
-| `install-awslocal` | Whether to install the `awslocal` CLI into the build environment                 | `true`   |
-| `lifetime`         | How long an ephemeral instance should live                                       | 30       |
-| `preview-cmd`          | Command(s) used to create a Ephemeral Instance of the PR (can use `$AWS_ENDPOINT_URL`) |  |
-| `skip-ephemeral-stop`        | Skip stopping LocalStack Ephemeral Instance | `false`  |
-| `skip-startup`     | Explicitly prevent LocalStack start up, only installs CLI(s). Recommended to manage state later on in the pipeline or start up an ephemeral instance. | `false`  |
-| `skip-wait`        | Skip waiting for LocalStack to start up | `false`  |
-| `state-action`     | Valid values are `load`, `save`, `start`, `stop`, `` (empty, don't manage state). Values `start`/`stop` only usable with app previews.  | `` |
-| `state-backend`    | Either store the state of LocalStack locally, as a Cloud Pod or start an Ephemeral Instance. Valid values are `cloud-pods`, `ephemeral` or `local`. Use this option in unison with `state-action` to control behaviour. | `cloud-pods`  |
-| `state-name`       | Name of the state artifact (without extension) | `false`  |
-| `use-pro`          | Whether to use the Pro version of LocalStack (requires API key to be configured) | `false`  |
+| Input                    | Description                                                                                                                                                                                                             | Default      |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
+| `auto-load-pod`          | Which pod to load on startup of LocalStack  (application preview)                                                                                                                                                       | `None`       |
+| `ci-project`             | Name of the CI project to track in LocalStack Cloud                                                                                                                                                                     |              |
+| `configuration`          | Configuration variables to use while starting LocalStack container                                                                                                                                                      | `None`       |
+| `extension-auto-install` | Which extensions to install on startup of LocalStack (application preview)                                                                                                                                              | `None`       | 
+| `github-token`           | Github token used to create PR comments                                                                                                                                                                                 |              |
+| `image-tag`              | Tag of the LocalStack Docker image to use                                                                                                                                                                               | `latest`     |
+| `include-preview`        | Whether to include the created Ephemeral Instance URL in the PR comment                                                                                                                                                 | `false`      |
+| `install-awslocal`       | Whether to install the `awslocal` CLI into the build environment                                                                                                                                                        | `true`       |
+| `lifetime`               | How long an ephemeral instance should live                                                                                                                                                                              | 30           |
+| `preview-cmd`            | Command(s) used to create a Ephemeral Instance of the PR (can use `$AWS_ENDPOINT_URL`)                                                                                                                                  |              |
+| `skip-ephemeral-stop`    | Skip stopping LocalStack Ephemeral Instance                                                                                                                                                                             | `false`      |
+| `skip-startup`           | Explicitly prevent LocalStack start up, only installs CLI(s). Recommended to manage state later on in the pipeline or start up an ephemeral instance.                                                                   | `false`      |
+| `skip-wait`              | Skip waiting for LocalStack to start up                                                                                                                                                                                 | `false`      |
+| `state-action`           | Valid values are `load`, `save`, `start`, `stop`, `` (empty, don't manage state). Values `start`/`stop` only usable with app previews.                                                                                  | ``           |
+| `state-backend`          | Either store the state of LocalStack locally, as a Cloud Pod or start an Ephemeral Instance. Valid values are `cloud-pods`, `ephemeral` or `local`. Use this option in unison with `state-action` to control behaviour. | `cloud-pods` |
+| `state-name`             | Name of the state artifact (without extension)                                                                                                                                                                          | `false`      |
+| `update-pip`             | Whether to update the current pip version when installing tools                                                                                                                                                         | `true`       |
+| `use-pro`                | Whether to use the Pro version of LocalStack (requires API key to be configured)                                                                                                                                        | `false`      |
 
 ## Example workflow
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,10 @@ inputs:
     description: 'The lifetime of the ephemeral instance, how long the instance should be available for'
     required: false
     default: '30'
+  update-pip:
+    description: 'Whether to update the current pip installation'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -104,6 +108,7 @@ runs:
         with: |-
           {
             "install-awslocal": ${{ toJSON(inputs.install-awslocal) }},
+            "update-pip": ${{ toJSON(inputs.update-pip) }},
           }
 
     - name: Start Localstack
@@ -121,7 +126,8 @@ runs:
             "use-pro": ${{ toJSON(inputs.use-pro) }},
             "configuration": ${{ toJSON(inputs.configuration) }},
             "ci-project": ${{ toJSON(inputs.ci-project) }},
-            "skip-wait": ${{ toJSON(inputs.skip-wait) }}
+            "skip-wait": ${{ toJSON(inputs.skip-wait) }},
+            "update-pip": ${{ toJSON(inputs.update-pip) }},
           }
 
     - name: Create Ephemeral Instance

--- a/startup/action.yml
+++ b/startup/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Skip wait for LocalStack'
     required: false
     default: 'false'
+  update-pip:
+    description: 'Whether to update the current pip installation'
+    required: true
+    default: 'true'
 
 runs:
   using: "composite"
@@ -56,6 +60,7 @@ runs:
         with: |-
           {
             "install-awslocal": ${{ toJSON(inputs.install-awslocal) }},
+            "update-pip": ${{ toJSON(inputs.update-pip) }},
           }
 
     - name: Start LocalStack
@@ -86,4 +91,5 @@ runs:
         USE_PRO: ${{ inputs.use-pro }}
         CONFIGURATION: ${{ inputs.configuration }}
         SKIP_WAIT: ${{ inputs.skip-wait }}
+        UPDATE_PIP: ${{ inputs.update-pip }}
 

--- a/tools/action.yml
+++ b/tools/action.yml
@@ -5,13 +5,19 @@ inputs:
     description: 'Whether to install the `awslocal` CLI into the environment'
     required: true
     default: 'true'
+  update-pip:
+    description: 'Whether to update the current pip installation'
+    required: true
+    default: 'true'
 
 runs:
   using: "composite"
   steps:
     - name: Start LocalStack
       run: |
-        pip install --upgrade pip
+        if [ "$UPDATE_PIP" = true ]; then
+          pip install --upgrade pip
+        fi
         which localstack > /dev/null || pip install localstack
         if [ "$INSTALL_AWSLOCAL" = true ]; then
           which awslocal > /dev/null || pip install awscli-local[ver1]
@@ -19,4 +25,4 @@ runs:
       shell: bash
       env:
         INSTALL_AWSLOCAL: "${{ inputs.install-awslocal }}"
-
+        UPDATE_PIP: "${{ inputs.update-pip }}"


### PR DESCRIPTION
Hello! 👋

Thanks for providing this nice action, it makes our CI-Life much easier! :)

We have a use-case where we use custom docker images which already have tools pre-installed. One of those tools is `pip` which was installed using the package manager of the distroy, therefore when this action runs `pip install --upgrade pip` it will fail our pipeline.

I added a new variable to disable this behaviour and skip the pip upgrade. The default behaviour is untouched, means it shouldn't break existing workflows / pipelines.