### PR TITLE
fix usage of GH_ACTION_VERSION by referencing pull_request.head.sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
             }
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_API_KEY }}
-          GH_ACTION_VERSION: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          GH_ACTION_VERSION: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
 
       - name: Run AWS Commands
         run: |


### PR DESCRIPTION
Following up #58: fixing oversight of one usage for the `GH_ACTION_VERSION` env, which still uses `github.head_ref` instead of `github.event.pull_request.head.sha`

This issue becomes evident when using dependabot, [CI run failed ](https://github.com/localstack/setup-localstack/actions/runs/21389927112?pr=57)for:

```
 Test Local State Load Action
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/_actions/LocalStack/setup-localstack/dependabot/startup'. Did you forget to run actions/checkout before running your local action?
```
