### PR TITLE
docs: note v0.3.2 as first immutable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.2]
+
+### Notes
+
+- **First immutable release.** This is the first release published with [GitHub Immutable Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-immutable-releases) enabled on the repository. The `v0.3.2` tag and its assets cannot be modified or deleted, and the release carries a signed attestation. Users are encouraged to pin to `v0.3.2` (or later) for supply-chain hardening.
+
+## [0.3.1]
+
+- Only show `use-pro` deprecation message on top action input ([#67](https://github.com/LocalStack/setup-localstack/pull/67)).
+
 ## [0.3.0]
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ A GitHub Action to setup [LocalStack](https://github.com/localstack/localstack) 
 
 ## Usage
 
+> **Pin to `v0.3.2` or later.** `v0.3.2` is the first release published with [GitHub Immutable Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-immutable-releases) enabled, meaning its tag and assets cannot be modified or deleted. Pinning to an immutable tag (or its commit SHA) protects your workflow from supply-chain tampering.
+
 ### Get started with a minimal example
 
 ```yml
 - name: Start LocalStack
-  uses: LocalStack/setup-localstack@v0.3.0
+  uses: LocalStack/setup-localstack@v0.3.2
   with:
     image-tag: 'latest'
     install-awslocal: 'true'
@@ -31,7 +33,7 @@ A GitHub Action to setup [LocalStack](https://github.com/localstack/localstack) 
 ### Install only CLIs and startup later
 ```yml
 - name: Install LocalStack CLIs
-  uses: LocalStack/setup-localstack@v0.3.0
+  uses: LocalStack/setup-localstack@v0.3.2
   with:
     skip-startup: 'true'
     install-awslocal: 'true'
@@ -39,7 +41,7 @@ A GitHub Action to setup [LocalStack](https://github.com/localstack/localstack) 
 ...
 
 - name: Start LocalStack
-  uses: LocalStack/setup-localstack@v0.3.0
+  uses: LocalStack/setup-localstack@v0.3.2
   with:
     image-tag: 'latest'
   env:
@@ -49,7 +51,7 @@ A GitHub Action to setup [LocalStack](https://github.com/localstack/localstack) 
 ### Save a state later on in the pipeline
 ```yml
 - name: Save LocalStack State
-  uses: LocalStack/setup-localstack@v0.3.0
+  uses: LocalStack/setup-localstack@v0.3.2
   with:
     install-awslocal: 'true'
     state-backend: cloud-pods
@@ -63,7 +65,7 @@ A GitHub Action to setup [LocalStack](https://github.com/localstack/localstack) 
 ### Load an already saved state
 ```yml
 - name: Start LocalStack and Load State
-  uses: LocalStack/setup-localstack@v0.3.0
+  uses: LocalStack/setup-localstack@v0.3.2
   with:
     install-awslocal: 'true'
     state-backend: cloud-pods
@@ -78,7 +80,7 @@ A GitHub Action to setup [LocalStack](https://github.com/localstack/localstack) 
 
 ### Manage Application Previews (on an Ephemeral Instance)
 ```yml
-uses: LocalStack/setup-localstack@v0.3.0
+uses: LocalStack/setup-localstack@v0.3.2
   with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       state-backend: ephemeral
@@ -93,7 +95,7 @@ uses: LocalStack/setup-localstack@v0.3.0
 ...
 
 with:
-  uses: LocalStack/setup-localstack@v0.3.0
+  uses: LocalStack/setup-localstack@v0.3.2
   with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       state-backend: ephemeral
@@ -137,7 +139,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.3.0
+        uses: LocalStack/setup-localstack@v0.3.2
         with:
           image-tag: 'latest'
           install-awslocal: 'true'
@@ -155,7 +157,7 @@ jobs:
           echo "Test Execution complete!"
 
       - name: Save LocalStack State
-        uses: LocalStack/setup-localstack@v0.3.0
+        uses: LocalStack/setup-localstack@v0.3.2
         with:
           state-backend: local
           state-action: save


### PR DESCRIPTION
## Motivation

[GitHub Immutable Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-immutable-releases) is now enabled at the repo level, but GitHub only applies it to releases published *after* the setting was flipped — `v0.3.1` and earlier remain mutable :warning: . This PR prepares the docs for `v0.3.2`, which will be the first immutable tag users can pin to for supply-chain hardening.

Fixes DRG-752

## Changes

- Added a callout to the top of the README's Usage section recommending users pin to `v0.3.2` (or later).
- Bumped all `LocalStack/setup-localstack@v0.3.0` references in example snippets to `@v0.3.2`.
- Added a `[0.3.2]` entry in `CHANGELOG.md` documenting the immutable-release milestone.
- Backfilled the skipped `[0.3.1]` entry while at it (referencing #67).

## Follow-ups

- [ ] Publish the `v0.3.2` release immediately after merging so the tag is actually immutable.