### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @localstack/devx


### PR DESCRIPTION
Assign default ownership of all files to @localstack/devx.

:heavy_check_mark:  verified validity of the `CODEOWNERS` file