### PR TITLE
fix: replace ToS-blocked maintain-one-comment action (fixes ephemeral test)

### DIFF
--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -69,11 +69,10 @@ runs:
         retry shutdown_instance
     
     - name: Update status comment
-      uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
-        token: ${{ inputs.github-token }}
-        body: |
-          The ephemeral instance for the application preview has been shut down
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: localstack-preview
         number: ${{ steps.pr.outputs.pr_id }}
+        message: |
+          The ephemeral instance for the application preview has been shut down

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -71,12 +71,11 @@ runs:
         fi
 
     - name: Update status comment
-      uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
-        token: ${{ inputs.github-token }}
-        body: |
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: localstack-preview
+        number: ${{ steps.pr.outputs.pr_id }}
+        message: |
           ${{ inputs.ci-project && format('{0}{1}', '🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/', inputs.ci-project) }}
           ${{ inputs.include-preview && format('{0}{1}', '🚀 Preview for this PR: ', env.LS_PREVIEW_URL) }}
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'
-        number: ${{ steps.pr.outputs.pr_id }}

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -23,10 +23,9 @@ runs:
         path: ./pr-id.txt
 
     - name: Create initial PR comment
-      uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
-        token: ${{ inputs.github-token }}
-        body: |
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: localstack-preview
+        message: |
           ⚡️ Running CI build with LocalStack ...
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'


### PR DESCRIPTION
## Root cause

The **ephemeral instance test** has failed on every PR since ~2026-06-08 with `Repository access blocked`, while `ci.yml` keeps passing.

The blocked repository is **`actions-cool/maintain-one-comment`** — GitHub blocked it for a **Terms of Service violation on 2026-05-19**:

```json
{ "message": "Repository access blocked",
  "block": { "reason": "tos", "created_at": "2026-05-19T00:34:15Z" } }
```

The Actions runner downloads actions through the GitHub API, so any step resolving this action dies at job prep (`Getting action download info`) before it runs — the exact failure annotation we saw. It's the only blocked action in the dependency tree; `jenseng/dynamic-uses`, `dawidd6/action-download-artifact`, and the `actions/*` ones all resolve fine. (Timeline fits: last green 2026-04-14 → blocked 2026-05-19 → failures from 2026-06-08.) No org allowlist change is involved, and no allowlisting can fix a ToS-blocked repo — it must be replaced.

## Change

Replace all three usages (`prepare`, `finish`, `ephemeral/shutdown`) with the maintained **`marocchino/sticky-pull-request-comment`** (SHA-pinned, v3.0.4):

- Shared `header: localstack-preview` preserves the single sticky-comment behaviour across the create → update → shutdown lifecycle.
- marocchino manages its own hidden marker, so the literal `<!-- Sticky Pull Request Comment -->` line is dropped from the message bodies.
- The `🚀 Preview for this PR:` text asserted by `ephemeral.yml` is preserved.

## Verification

This PR triggers `ephemeral.yml` — the deploy/shutdown steps should now get past `Repository access blocked`, and the "Check PR Comments for preview text" assertion should find the sticky comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)