### PR TITLE
demo: show live preview comment (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -67,19 +67,8 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
-          
-      # We want explicit shutdown
-      - name: Shutdown ephemeral instance
-        if: ${{ always() }}
-        uses: jenseng/dynamic-uses@8bc24f0360175e710da532c4d19eafdbed489a06 # v1
-        with:
-          uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
-          with: |-
-            {
-              "github-token": ${{ toJSON(secrets.GITHUB_TOKEN) }},
-              "state-backend": "ephemeral",
-              "state-action": "stop"
-            }
-        env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          GH_ACTION_VERSION: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.ref_name }}
+
+      # DEMO ONLY (do not merge): shutdown step intentionally removed so the
+      # sticky PR comment stays on the "Preview for this PR" state instead of
+      # being overwritten by the "shut down" message. The instance still
+      # auto-expires via its 5-minute lifetime, so nothing is left running.

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -69,11 +69,10 @@ runs:
         retry shutdown_instance
     
     - name: Update status comment
-      uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
-        token: ${{ inputs.github-token }}
-        body: |
-          The ephemeral instance for the application preview has been shut down
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: localstack-preview
         number: ${{ steps.pr.outputs.pr_id }}
+        message: |
+          The ephemeral instance for the application preview has been shut down

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -71,12 +71,11 @@ runs:
         fi
 
     - name: Update status comment
-      uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
-        token: ${{ inputs.github-token }}
-        body: |
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: localstack-preview
+        number: ${{ steps.pr.outputs.pr_id }}
+        message: |
           ${{ inputs.ci-project && format('{0}{1}', '🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/', inputs.ci-project) }}
           ${{ inputs.include-preview && format('{0}{1}', '🚀 Preview for this PR: ', env.LS_PREVIEW_URL) }}
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'
-        number: ${{ steps.pr.outputs.pr_id }}

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -23,10 +23,9 @@ runs:
         path: ./pr-id.txt
 
     - name: Create initial PR comment
-      uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
-        token: ${{ inputs.github-token }}
-        body: |
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        header: localstack-preview
+        message: |
           ⚡️ Running CI build with LocalStack ...
-          <!-- Sticky Pull Request Comment -->
-        body-include: '<!-- Sticky Pull Request Comment -->'


### PR DESCRIPTION
Throwaway demo off the #75 fix branch. The `ephemeral.yml` shutdown step is removed so the marocchino sticky comment stays on the **🚀 Preview for this PR** state instead of being overwritten by the shutdown message.

The ephemeral instance auto-expires via `lifetime: 5`, so nothing is left running. **Do not merge — delete after viewing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)